### PR TITLE
upgrade sqlite3 to version that supports node6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "bluebird": "2.9.27",
     "inet": "0.0.3",
-    "sqlite3": "3.0.8"
+    "sqlite3": "3.1.4"
   },
   "devDependencies": {
     "chai": "2.3.0",


### PR DESCRIPTION
Minor change. New release should be 0.5.0
